### PR TITLE
fix(thermostat): Use Auto mode if capability thermostat_mode is not u…

### DIFF
--- a/lib/maps/thermostat.js
+++ b/lib/maps/thermostat.js
@@ -8,24 +8,12 @@ module.exports = (Mapper, Service, Characteristic) => ({
     // don't need to fake thermostat mode if the device has the real thing
     if (Mapper.Utils.hasCapability(device, 'thermostat_mode')) return;
 
-    let target, current, toUpdate;
-    switch(characteristic) {
-      case 'TargetTemperature':
-        target   = newValue;
-        current  = service.getCharacteristic(Characteristic.CurrentTemperature).value;
-        toUpdate = Characteristic.TargetHeatingCoolingState;
-        break;
-      case 'CurrentTemperature':
-        current  = newValue;
-        target   = service.getCharacteristic(Characteristic.TargetTemperature).value;
-        toUpdate = Characteristic.CurrentHeatingCoolingState;
-        break;
-      default:
-        return;
-    }
-    const newState = Characteristic.CurrentHeatingCoolingState[ current >= (target + 0.5) ? 'OFF' : 'HEAT' ];
-    service.getCharacteristic(Characteristic.CurrentHeatingCoolingState).updateValue(newState);
-    service.getCharacteristic(Characteristic.TargetHeatingCoolingState) .updateValue(newState);
+    // If the capability 'thermostat_mode' is not used, remove all modes and support only AUTO Mode
+    service.getCharacteristic(Characteristic.TargetHeatingCoolingState).setProps({
+      validValues: [Characteristic.TargetHeatingCoolingState.AUTO],
+      maxValue: Characteristic.TargetHeatingCoolingState.AUTO,
+      minValue: Characteristic.TargetHeatingCoolingState.AUTO
+    });
   },
   required: {
     target_temperature:  Mapper.Characteristics.Temperature.Target,


### PR DESCRIPTION
## Problem
When the thermostat_mode capability is not utilized, the TargetHeatingCoolingState is currently being determined based on the current temperature and target temperature. This approach involves unnecessary calculations and assumptions, which can lead to incorrect state settings.

## Fix
To simplify the implementation and avoid unnecessary calculations, I removed the dynamic determination of TargetHeatingCoolingState. Now, if the thermostat_mode capability is not used, the TargetHeatingCoolingState is set to AUTO by default. This ensures a consistent and predictable behavior without the need for additional calculations or guesses.

## Result
![IMG_C685EB135CC4-1](https://github.com/robertklep/name.klep.homekitty/assets/16178688/836d1150-51db-41ce-98e2-98b694cc7e0d)
