### PR TITLE
fix(thermostat): Fix initial heating cooling state [-]

### DIFF
--- a/lib/maps/thermostat.js
+++ b/lib/maps/thermostat.js
@@ -9,6 +9,7 @@ module.exports = (Mapper, Service, Characteristic) => ({
     if (Mapper.Utils.hasCapability(device, 'thermostat_mode')) return;
 
     // If the capability 'thermostat_mode' is not used, remove all modes and support only AUTO Mode
+    service.getCharacteristic(Characteristic.TargetHeatingCoolingState).updateValue(Characteristic.TargetHeatingCoolingState.AUTO);
     service.getCharacteristic(Characteristic.TargetHeatingCoolingState).setProps({
       validValues: [Characteristic.TargetHeatingCoolingState.AUTO],
       maxValue: Characteristic.TargetHeatingCoolingState.AUTO,


### PR DESCRIPTION
@robertklep I missed that the initial HeatingCoolingState is set to OFF. Therefore, I need to set the HeatingCoolingState to AUTO first before restricting the possible values; otherwise, it will log an error. It should be correct now—sorry!