### PR TITLE
windowcovering - tilt support

### DIFF
--- a/lib/mapper-accessors.js
+++ b/lib/mapper-accessors.js
@@ -117,6 +117,10 @@ module.exports = Mapper => {
         get : value => Characteristic.TargetHeatingCoolingState[ value.toUpperCase() ],
         set : value => [ 'off', 'heat', 'cool', 'auto' ][value],
       }
+    },
+    TiltAngle: {
+      get : value => value * 180 - 90,
+      set : value => (value + 90) / 180,
     }
   };
 };

--- a/lib/mapper-characteristics.js
+++ b/lib/mapper-characteristics.js
@@ -43,6 +43,10 @@ module.exports = Mapper => {
       State : {
         characteristics: Characteristic.PositionState,
         ...Mapper.Accessors.PositionState
+      },
+      Tilt: {
+        characteristics: [ Characteristic.CurrentHorizontalTiltAngle, Characteristic.TargetHorizontalTiltAngle ],
+        ...Mapper.Accessors.TiltAngle
       }
     }
   };

--- a/lib/maps/windowcovering-tilt.js
+++ b/lib/maps/windowcovering-tilt.js
@@ -1,0 +1,7 @@
+module.exports = (Mapper, Service, Characteristic) => ({
+    class:    [ 'curtain', 'blinds', 'sunshade', 'windowcoverings' ],
+    service:  Service.WindowCovering,
+    required: {
+        windowcoverings_tilt_set : Mapper.Characteristics.WindowCoverings.Tilt
+    }
+});


### PR DESCRIPTION
Hi,

I've added support for window covering tilt and submitted a pull request for review. I’ve thoroughly tested it, and everything seems to be working smoothly.

In HomeKit, tilt values range from -90 to 90 degrees, whereas Homey uses a 0 to 1 scale (in 0.1 increments). As a result, I implemented a conversion between these two value systems.

Could you please review the pull request? I hope I didn’t overlook anything.

Thanks!