### PR TITLE
Add OccupancySensor map for alarm_occupancy

### DIFF
--- a/lib/maps/occupancy-sensor.js
+++ b/lib/maps/occupancy-sensor.js
@@ -1,0 +1,16 @@
+module.exports = (Mapper, Service, Characteristic) => ({
+  class : ['sensor', 'other'],
+  service: Service.OccupancySensor,
+  required: {
+    alarm_occupancy : {
+      characteristics : Characteristic.OccupancyDetected,
+      ...Mapper.Accessors.Boolean
+    }
+  },
+  optional : {
+    alarm_tamper : {
+      characteristics : Characteristic.StatusTampered,
+      ...Mapper.Accessors.Boolean
+    },
+  }
+});


### PR DESCRIPTION
### Problem

Devices that expose Homey's `alarm_occupancy` capability are reported as `{ supported: false, exposed: false }` and never reach HomeKit — there's currently no map for HomeKit's `OccupancySensor` service.

For occupancy-type devices the only workarounds today are `alarm_contact` (shows as "Open/Closed", and the polarity reads backwards: *occupied* → "Open") or `alarm_motion` ("Motion detected", which is misleading for something that isn't moving). Neither is really right.

### Change

Adds `lib/maps/occupancy-sensor.js`, modelled directly on `motion-sensor.js`.

`OccupancyDetected` has the same "detected when true" semantics as `MotionDetected`, so `Mapper.Accessors.Boolean` is the correct accessor:

- `alarm_occupancy = true` → `OCCUPANCY_DETECTED`
- `alarm_occupancy = false` → `OCCUPANCY_NOT_DETECTED`

`alarm_tamper` is included as optional, matching the other sensor maps. Maps are auto-loaded from `lib/maps/`, so no registration is needed.

### Testing

Built and installed on a Homey Pro (firmware 13.3.0, HomeKitty 2.5.6) with a Device Capabilities virtual device exposing `alarm_occupancy` (a GPS-driven parking-space sensor).

- Before: `"homekitty": { "supported": false, "exposed": false }` — absent from the Home app
- After: `"homekitty": { "supported": true, "exposed": true }` — appears as an Occupancy Sensor and correctly reports occupied / not occupied, tracking state changes live

Thanks for HomeKitty — the per-map structure made this a pleasant one-file addition. 🐱

🤖 Generated with [Claude Code](https://claude.com/claude-code)