### PR TITLE
Thermostat: show Idle vs Heating/Cooling using operational_state

### DIFF
--- a/lib/mapper-accessors.js
+++ b/lib/mapper-accessors.js
@@ -2,6 +2,31 @@ const { Accessory, Service, Characteristic, AccessoryEventTypes, uuid } = requir
 
 const getFanSpeed = device => device.capabilitiesObj?.fan_speed ?? device.capabilitiesObj?.dim ?? {};
 
+// Derive CurrentHeatingCoolingState. If the device has the standard
+// `operational_state` capability, use it to determine whether the device is
+// actively heating/cooling (`running` means active). Otherwise, fall back to
+// `thermostat_mode`, where `auto` mode (which HomeKit doesn't support) is
+// derived from the current and target temperatures.
+const getCurrentHeatingCoolingState = (device, mode, state = device.capabilitiesObj?.operational_state?.value) => {
+  const State = Characteristic.CurrentHeatingCoolingState;
+
+  if (state !== undefined && state !== null) {
+    if (state !== 'running') return State.OFF;
+    // running: derive the direction (heat/cool) from the mode below
+  } else if (mode === 'off') {
+    return State.OFF;
+  }
+
+  if (mode === 'cool') return State.COOL;
+  if (mode !== 'auto') return State.HEAT;
+
+  const currentTemperature = device.capabilitiesObj?.measure_temperature?.value;
+  const targetTemperature  = device.capabilitiesObj?.target_temperature?.value;
+  return currentTemperature < targetTemperature ? State.HEAT :
+         currentTemperature > targetTemperature ? State.COOL :
+         State.OFF;
+};
+
 module.exports = Mapper => {
   Mapper.Accessors = {
     Identity : {
@@ -126,19 +151,14 @@ module.exports = Mapper => {
     },
     HeatingCoolingState : {
       Current : {
-        // Homey supports `auto` mode, HomeKit doesn't.
-        get: (value, { device }) => {
-          const currentTemperature = device.capabilitiesObj?.measure_temperature?.value;
-          const targetTemperature = device.capabilitiesObj?.target_temperature?.value;
-          const currentValue = value !== 'auto'
-            ? value.toUpperCase()
-            : currentTemperature < targetTemperature
-              ? 'HEAT'
-              : currentTemperature > targetTemperature
-                ? 'COOL'
-                : 'OFF';
-          return Characteristic.CurrentHeatingCoolingState[currentValue];
-        }
+        // value is `thermostat_mode`
+        get: (value, { device }) => getCurrentHeatingCoolingState(device, value),
+      },
+      CurrentFromState : {
+        // value is `operational_state`: mapping it separately makes sure that
+        // CurrentHeatingCoolingState gets updated immediately when the
+        // device's activity changes
+        get: (value, { device }) => getCurrentHeatingCoolingState(device, device.capabilitiesObj?.thermostat_mode?.value, value),
       },
       Target : {
         get : value => Characteristic.TargetHeatingCoolingState[ value.toUpperCase() ],

--- a/lib/mapper-characteristics.js
+++ b/lib/mapper-characteristics.js
@@ -29,6 +29,7 @@ module.exports = Mapper => {
     },
     HeatingCoolingState : {
       Current: { characteristics : Characteristic.CurrentHeatingCoolingState, ...Mapper.Accessors.HeatingCoolingState.Current },
+      CurrentFromState: { characteristics : Characteristic.CurrentHeatingCoolingState, ...Mapper.Accessors.HeatingCoolingState.CurrentFromState },
       Target:  { characteristics : Characteristic.TargetHeatingCoolingState,  ...Mapper.Accessors.HeatingCoolingState.Target },
     },
     Light:         {

--- a/lib/maps/thermostat.js
+++ b/lib/maps/thermostat.js
@@ -81,6 +81,10 @@ module.exports = (Mapper, Service, Characteristic) => ({
       Mapper.Characteristics.HeatingCoolingState.Current,
       Mapper.Characteristics.HeatingCoolingState.Target,
     ],
+    // devices that report their actual activity through the standard
+    // `operational_state` capability can show "Idle" vs "Heating"/"Cooling"
+    // in the Home app
+    operational_state: Mapper.Characteristics.HeatingCoolingState.CurrentFromState,
     // Optional
     measure_humidity: Mapper.Characteristics.RelativeHumidity.Current,
   }


### PR DESCRIPTION
## Problem

The thermostat map uses `thermostat_mode` for both `TargetHeatingCoolingState` and `CurrentHeatingCoolingState`. So when a thermostat is set to heat mode but is not actively heating right now, the Home app still shows "Heating". It never shows "Idle".

## Change

When the device has the standard `operational_state` capability (system capability since Homey v12.2.0, values `stopped` / `running` / `paused` / `error`), it is now used for `CurrentHeatingCoolingState`:

- `running` → `HEAT` or `COOL` (direction from `thermostat_mode`)
- any other value → `OFF`, so the Home app shows "Idle"

`operational_state` is mapped as its own (optional) capability, so the Home app updates as soon as the activity changes.

Devices without `operational_state` behave the same as before. One small side effect: an unknown `thermostat_mode` value now falls back to `HEAT`, instead of producing an invalid characteristic value (`Characteristic.CurrentHeatingCoolingState[value.toUpperCase()]` is `undefined` for custom modes).

The logic now lives in one helper function (`getCurrentHeatingCoolingState`), so updates from `thermostat_mode` and `operational_state` always agree.

## Testing

- Ran the getter logic against 15 cases (running/stopped/paused/error, no operational_state, all modes including `auto`) — all pass
- Running this build on my Homey Pro. My thermostats report `operational_state`, and the Home app now shows Idle vs Heating/Cooling correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)