### PR TITLE
Use only supported thermostat modes

### DIFF
--- a/lib/maps/thermostat.js
+++ b/lib/maps/thermostat.js
@@ -24,6 +24,19 @@ module.exports = (Mapper, Service, Characteristic) => ({
     }
   ],
   onService: (service, { device }) => {
+    // restrict the HomeKit modes to the values supported by the device's thermostat_mode capability
+    const modes = device.capabilitiesObj?.thermostat_mode?.values;
+    if (modes?.length) {
+      const states = Characteristic.TargetHeatingCoolingState;
+      const validValues = modes
+        .map(mode => Characteristic.TargetHeatingCoolingState[ String(mode.id).toUpperCase() ])
+        .filter(value => [ states.OFF, states.HEAT, states.COOL, states.AUTO ].includes(value));
+
+      if (validValues.length) {
+        service.getCharacteristic(Characteristic.TargetHeatingCoolingState).setProps({ validValues });
+      }
+    }
+
     // set target temperature props to match Homey's values
     const target_temperature = device.capabilitiesObj?.target_temperature;
     if (target_temperature) {


### PR DESCRIPTION
**What:**

For devices that have the thermostat_mode capability, the Thermostat map now reads the capability's allowed values (capabilitiesObj.thermostat_mode.values) and restricts HomeKit's TargetHeatingCoolingState to those modes via setProps({ validValues }).

**Why:**

HomeKit offers all four modes (Off / Heat / Cool / Auto) by default. Many Homey devices restrict thermostat_mode to a subset through capabilitiesOptions.values — e.g. my thermostat only supports heat and cool. Selecting one of the unsupported modes in the Home app fails on the Homey side and leaves HomeKit out of sync. With this change, the Home app only shows the modes the device actually supports.

**Notes:**

- Mode ids are mapped case-insensitively and validated against the TargetHeatingCoolingState enum (OFF/HEAT/COOL/AUTO); unknown ids are ignored.
- If no usable values remain, setProps is skipped, keeping today's behaviour (all four modes).
- Devices without thermostat_mode are unaffected — the existing AUTO-only fallback in onUpdate still applies.

Tested with a heat/cool-only thermostat: the Home app now shows only Heat and Cool.